### PR TITLE
More fixes to pagination

### DIFF
--- a/src/components/resources.vue
+++ b/src/components/resources.vue
@@ -122,6 +122,7 @@ export default {
 
             this.resources = sortedResources;
             localStorage.setItem('resources', JSON.stringify(storageObject));
+            this.$root.$emit('resourcesChanged');
         },
         onScroll() {
             if (window.innerHeight + window.pageYOffset >= document.body.scrollHeight) {

--- a/src/components/resources.vue
+++ b/src/components/resources.vue
@@ -76,7 +76,7 @@ export default {
             let resources = [];
 
             for (let page = 0; page <= this.currentPage; page++) {
-                if (!chunkedResources[page]) continue;
+                if (chunkedResources[page] == undefined) continue;
                 resources = resources.concat(chunkedResources[page]);
             }
 
@@ -131,6 +131,7 @@ export default {
 
                 if (this.currentPage > chunkedResources.length - 1) {
                     this.currentPage = chunkedResources.length - 1;
+                    if (this.currentPage < 0) this.currentPage = 0;
                 }
             }
         }

--- a/src/components/resources.vue
+++ b/src/components/resources.vue
@@ -72,12 +72,11 @@ export default {
             return sortedResources;
         },
         paginatedResources() {
-            if (this.formattedResources.length === 0) return [];
-
             let chunkedResources = this.array_chunk(this.formattedResources, this.perPage);
             let resources = [];
 
             for (let page = 0; page <= this.currentPage; page++) {
+                if (!chunkedResources[page]) continue;
                 resources = resources.concat(chunkedResources[page]);
             }
 

--- a/src/components/sidebar.vue
+++ b/src/components/sidebar.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="sidebar">
+    <div v-show="resources.length > 0" class="sidebar">
         <a
             :href="'/?q=' + tag"
             v-for="[tag, count] in Object.entries(tagList)"
@@ -16,7 +16,18 @@ export default {
         };
     },
     mounted() {
-        this.resources = JSON.parse(localStorage.getItem('resources')).resources;
+        this.getResources();
+        this.$root.$on('resourcesChanged', this.getResources);
+    },
+    destroyed() {
+        this.$root.off('resources', this.getResources);
+    },
+    methods: {
+        getResources() {
+            const storage = JSON.parse(localStorage.getItem('resources'));
+
+            this.resources = storage !== null ? storage.resources : [];
+        }
     },
     computed: {
         tagList() {


### PR DESCRIPTION
Hey. It's me again. Thanks for merging my previous pull request. However, I noticed there were still some errors at some cases. I guess there is some problem with pagination logic. At `resources.vue` there is `paginatedResources` method and somehow this method causes to append an `undefined` object at last index in the array when scrolling page few times and then typing smth into search bar. It is undefined but it is still rendered in the html template as `resource-card` but neither url neither any paramaters can be get, so it throws errors `TypeError: Cannot read property 'url' of undefined`. It is late now so please double test that to assure it is fixed.

Also I had to add event to properly load local storage in the sidebar because it isn't reactive by default. It could be rendered as empty box since newcomers don't have any data in the storage at first visit. Now it is fixed.